### PR TITLE
Safe edit_message catching telegram FloodWaitError

### DIFF
--- a/telethon-downloader/download_worker.py
+++ b/telethon-downloader/download_worker.py
@@ -14,6 +14,7 @@ from logger import logger
 from model.timer import Timer
 from utils import split_input, progress_bar, tg_reply_message
 from youtube import download_youtube_video
+from safe_telegram_client import safe_edit_message
 
 youtube_list = split_input(YOUTUBE_LINKS_SOPORTED)
 
@@ -34,6 +35,7 @@ def get_file_name(message: Message) -> str:
     return file_name
 
 
+
 # Printing download progress
 async def callback_progress(current: int, total: int, message, download_path: str, start: float, timer: Timer):
     speed = "%.2f Mbps" % (current // (time.perf_counter() -
@@ -41,7 +43,7 @@ async def callback_progress(current: int, total: int, message, download_path: st
     progress = progress_bar(current, total, suffix=speed)
     try:
         if timer.can_send() or current == total:
-            await client.edit_message(message,
+            await safe_edit_message(message,
                                       f'⬇️ Downloading in: <i>"{download_path}"</i>'
                                       f'\n\n{progress}')
     except Exception as e:
@@ -73,7 +75,7 @@ async def download_worker():
 
         logger.info(f"getDownloadPath FILE [{file_name}] to [{file_path}]")
 
-        await client.edit_message(update, f'Downloading in:\n<i>"{file_path}"</i>')
+        await safe_edit_message(update, f'Downloading in:\n<i>"{file_path}"</i>')
         await asyncio.sleep(1)
 
         logger.info('Downloading... ')
@@ -110,7 +112,7 @@ async def download_worker():
             ######
             logger.info('DOWNLOAD FINISHED %s [%s] => [%s]' % (end_time, file_name, file_path))
             await asyncio.sleep(1)
-            await client.edit_message(update, '👍 Downloading finished:\n%s \nIN: %s\nat %s' % (
+            await safe_edit_message(update, '👍 Downloading finished:\n%s \nIN: %s\nat %s' % (
                 file_name, file_path, end_time_short))
 
         except asyncio.TimeoutError:

--- a/telethon-downloader/safe_telegram_client.py
+++ b/telethon-downloader/safe_telegram_client.py
@@ -1,0 +1,20 @@
+from clients import client
+import time
+from logger import logger
+from telethon.errors import FloodWaitError
+
+async def safe_edit_message(messageId, text):
+    try:
+        await client.edit_message(messageId, text)
+    except FloodWaitError as e:
+        logger.warn(f"Flood wait error: Need to wait for {e.seconds} seconds")
+        time.sleep(e.seconds)
+        await safe_edit_message(messageId, text)
+
+async def safe_send_message(userId, text, buttons=None):
+    try:
+        await client.send_message(userId, text, buttons)
+    except FloodWaitError as e:
+        logger.warn(f"Flood wait error: Need to wait for {e.seconds} seconds")
+        time.sleep(e.seconds)
+        await safe_send_message(userId, text, buttons)

--- a/telethon-downloader/utils.py
+++ b/telethon-downloader/utils.py
@@ -12,7 +12,7 @@ from env import PATH_COMPLETED, TG_AUTHORIZED_USER_ID, AUTHORIZED_USER, user_ids
 from logger import logger
 from model.last_message import LastMessage
 from model.timer import Timer
-
+from safe_telegram_client import safe_send_message
 
 def splash() -> None:
     """ Displays splash screen """
@@ -187,14 +187,14 @@ def replace_right(source, target, replacement, replacements=None):
 
 async def tg_send_message_to_admin(msg):
     if AUTHORIZED_USER:
-        return await client.send_message(user_ids[0], msg)
+        return await safe_send_message(user_ids[0], msg)
     else:
-        await client.send_message(user_ids[0], 'ERROR: NO AUTHORIZED USER')
+        await safe_send_message(user_ids[0], 'ERROR: NO AUTHORIZED USER')
         raise Exception('ERROR: NO AUTHORIZED USER')
 
 
 async def tg_send_message(user_id, msg, operation=None, buttons=None, arg=None):
-    mes = await client.send_message(user_id, msg, buttons=buttons)
+    mes = await safe_send_message(user_id, msg, buttons=buttons)
     user_id = int(user_id.user_id) if hasattr(user_id, 'user_id') else int(user_id)
     if operation is None:
         last_messages[user_id] = None


### PR DESCRIPTION
Catch safely FloodWaitError. 

FloodWaitError is an exception due to a new policy in Telegram to avoid spamming through their own API.

https://docs.telethon.dev/en/stable/concepts/errors.html

The docs from Telethon report that the library stalls for 60 seconds by default, but not any longer.

The best solution to avoid this is to disable the progress display through `TG_PROGRESS_DOWNLOAD=False`, since edits on message still build up on the queuing.

This PR makes so that FloodWaitError is still handled correctly, and downloads can continue regardless.
